### PR TITLE
support random port to start rpc server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,17 @@
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa</groupId>
+            <artifactId>bolt</artifactId>
+            <version>1.6.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
             <artifactId>sofa-rpc-all</artifactId>
             <version>5.7.6</version>
             <exclusions>

--- a/src/main/java/com/baidu/hugegraph/config/RpcOptions.java
+++ b/src/main/java/com/baidu/hugegraph/config/RpcOptions.java
@@ -52,7 +52,7 @@ public class RpcOptions extends OptionHolder {
             new ConfigOption<>(
                     "rpc.server_port",
                     "The port bound by rpc server to provide services.",
-                    rangeInt(1, Integer.MAX_VALUE),
+                    rangeInt(0, Integer.MAX_VALUE),
                     8090
             );
 

--- a/src/main/java/com/baidu/hugegraph/config/RpcOptions.java
+++ b/src/main/java/com/baidu/hugegraph/config/RpcOptions.java
@@ -56,6 +56,17 @@ public class RpcOptions extends OptionHolder {
                     8090
             );
 
+    public static final ConfigOption<Boolean> RPC_ADAPTIVE_PORT =
+            new ConfigOption<>(
+                    "rpc.server_adaptive_port",
+                    "Whether the bound port is adaptive, if it's enabled, " +
+                    "when the port is in use, automatically +1 to detect " +
+                    "the next available port. Note that this process is " +
+                    "not atomic, so there may still be port conflicts.",
+                    disallowEmpty(),
+                    false
+            );
+
     public static final ConfigOption<Integer> RPC_SERVER_TIMEOUT =
             new ConfigOption<>(
                     "rpc.server_timeout",

--- a/src/main/java/com/baidu/hugegraph/rpc/RpcServer.java
+++ b/src/main/java/com/baidu/hugegraph/rpc/RpcServer.java
@@ -24,11 +24,15 @@ import java.util.Map;
 import org.apache.commons.collections.MapUtils;
 import org.slf4j.Logger;
 
+import com.alipay.remoting.RemotingServer;
 import com.alipay.sofa.rpc.common.utils.StringUtils;
 import com.alipay.sofa.rpc.config.ProviderConfig;
 import com.alipay.sofa.rpc.config.ServerConfig;
+import com.alipay.sofa.rpc.server.Server;
+import com.alipay.sofa.rpc.server.bolt.BoltServer;
 import com.baidu.hugegraph.config.HugeConfig;
 import com.baidu.hugegraph.config.RpcOptions;
+import com.baidu.hugegraph.testutil.Whitebox;
 import com.baidu.hugegraph.util.E;
 import com.baidu.hugegraph.util.Log;
 
@@ -73,6 +77,18 @@ public class RpcServer {
 
     public int port() {
         this.checkEnabled();
+        Server server = this.serverConfig.getServer();
+        if (server instanceof BoltServer && server.isStarted()) {
+            /*
+             * When using random port 0, try to fetch the actual port
+             * TODO: remove this code after adding Server.port() interface
+             *       https://github.com/sofastack/sofa-rpc/issues/1022
+             */
+            RemotingServer rs = Whitebox.getInternalState(server,
+                                                          "remotingServer");
+            return rs.port();
+        }
+        // When using random port 0, the returned port is not the actual port
         return this.serverConfig.getPort();
     }
 

--- a/src/main/java/com/baidu/hugegraph/rpc/RpcServer.java
+++ b/src/main/java/com/baidu/hugegraph/rpc/RpcServer.java
@@ -83,7 +83,10 @@ public class RpcServer {
         if (server instanceof BoltServer && server.isStarted()) {
             /*
              * When using random port 0, try to fetch the actual port
-             * TODO: remove this code after adding Server.port() interface
+             * NOTE: RemotingServer.port() would return the actual port only
+             *       if sofa-bolt version >= 1.6.1, please see:
+             *       https://github.com/sofastack/sofa-bolt/issues/196
+             * TODO: remove this code after adding Server.port() interface:
              *       https://github.com/sofastack/sofa-rpc/issues/1022
              */
             RemotingServer rs = Whitebox.getInternalState(server,

--- a/src/main/java/com/baidu/hugegraph/rpc/RpcServer.java
+++ b/src/main/java/com/baidu/hugegraph/rpc/RpcServer.java
@@ -52,9 +52,11 @@ public class RpcServer {
         String host = config.get(RpcOptions.RPC_SERVER_HOST);
         if (StringUtils.isNotBlank(host)) {
             int port = config.get(RpcOptions.RPC_SERVER_PORT);
+            boolean adaptivePort = config.get(RpcOptions.RPC_ADAPTIVE_PORT);
             this.serverConfig = new ServerConfig();
             this.serverConfig.setProtocol(config.get(RpcOptions.RPC_PROTOCOL))
                              .setHost(host).setPort(port)
+                             .setAdaptivePort(adaptivePort)
                              .setDaemon(false);
         } else {
             this.serverConfig = null;

--- a/src/test/java/com/baidu/hugegraph/unit/ServerClientTest.java
+++ b/src/test/java/com/baidu/hugegraph/unit/ServerClientTest.java
@@ -19,6 +19,9 @@
 
 package com.baidu.hugegraph.unit;
 
+import java.io.IOException;
+import java.net.ServerSocket;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -127,6 +130,38 @@ public class ServerClientTest extends BaseUnitTest {
         Assert.assertEquals(5.14, g1.result(), 0.00000001d);
         Assert.assertEquals(6.14, g2.result(), 0.00000001d);
         Assert.assertEquals(103.14, g3.result(), 0.00000001d);
+    }
+
+    @Test
+    public void testStartServerWithRandomPort() {
+        // Init server
+        RpcServer rpcServerRandom = new RpcServer(config("server-random"));
+        RpcProviderConfig serverConfig = rpcServerRandom.config();
+        serverConfig.addService(HelloService.class, new HelloServiceImpl());
+        startServer(rpcServerRandom);
+
+        Assert.assertNotEquals(0, rpcServerRandom.port());
+        Assert.assertNotEquals(8090, rpcServerRandom.port());
+
+        // Init client
+        HugeConfig config = config(false);
+        String url = rpcServerRandom.host() + ":" + rpcServerRandom.port();
+        String remoteUrlKey = com.baidu.hugegraph.config
+                                 .RpcOptions.RPC_REMOTE_URL.name();
+        config.setProperty(remoteUrlKey, url);
+        RpcClientProvider rpcClientRandom = new RpcClientProvider(config);
+
+        RpcConsumerConfig clientConfig = rpcClientRandom.config();
+        HelloService client = clientConfig.serviceProxy(HelloService.class);
+
+        // Test call
+        Assert.assertEquals("hello tom!", client.hello("tom"));
+        Assert.assertEquals("tom", client.echo("tom"));
+        Assert.assertEquals(5.14, client.sum(2, 3.14), 0.00000001d);
+
+        // Destroy all
+        rpcClientRandom.destroy();
+        stopServer(rpcServerRandom);
     }
 
     @Test

--- a/src/test/resources/rpc-server-adaptive.properties
+++ b/src/test/resources/rpc-server-adaptive.properties
@@ -1,0 +1,10 @@
+rpc.server_host=127.0.0.1
+rpc.server_port=8098
+rpc.server_adaptive_port=true
+#rpc.server_timeout=30
+#rpc.remote_url=127.0.0.1:8090
+#rpc.client_connect_timeout=20
+#rpc.client_reconnect_period=10
+#rpc.client_read_timeout=40
+#rpc.client_retries=3
+#rpc.client_load_balancer=consistentHash

--- a/src/test/resources/rpc-server-random.properties
+++ b/src/test/resources/rpc-server-random.properties
@@ -1,0 +1,9 @@
+rpc.server_host=127.0.0.1
+rpc.server_port=0
+#rpc.server_timeout=30
+#rpc.remote_url=127.0.0.1:8090
+#rpc.client_connect_timeout=20
+#rpc.client_reconnect_period=10
+#rpc.client_read_timeout=40
+#rpc.client_retries=3
+#rpc.client_load_balancer=consistentHash


### PR DESCRIPTION
* support random port 0 for rpc-server
* add rpc.server_adaptive_port option
* use bolt v1.6.2 instead of v1.5.6 to get RemotingServer.port()